### PR TITLE
license_url was missing a /

### DIFF
--- a/templates/design-system-base.html
+++ b/templates/design-system-base.html
@@ -36,7 +36,7 @@
 
 {% block footer %}
 {% set github_url = "https://github.com/digital-land/design-system" %}
-{% set licence_url = licence_url | default(github_url + 'blob/master/LICENSE') %}
+{% set licence_url = licence_url | default(github_url + '/blob/master/LICENSE') %}
 {{ govukFooter({
     "classes": "app-footer app-footer--full",
     "containerClasses" : "app-width-container",


### PR DESCRIPTION
Hovered over the "open source" bit of "The software used to build these pages is open source." and noticed the link was:

https://github.com/digital-land/design-systemblob/master/LICENSE

Added a slash back in so it's valid

(The newline at the end was added by the GitHub editor)