### PR TITLE
Remove duplicate the link tag for the frontend css

### DIFF
--- a/templates/design-system-base.html
+++ b/templates/design-system-base.html
@@ -6,9 +6,8 @@
 
 {%- block pageTitle %}{% if section %}{{ section|capitalize }} | {% endif %}Design system | Digital Land{% endblock -%}
 
-{% block head %}
+{% block dlCss %}
 {{super()}}
-<link href="{{ staticPath|default('/static') }}/stylesheets/dl-frontend.css" rel="stylesheet" />
 <link href="{{ staticPath|default('/static') }}/stylesheets/styleguide.css" rel="stylesheet" />
 {% endblock %}
 

--- a/templates/design-system-base.html
+++ b/templates/design-system-base.html
@@ -6,10 +6,10 @@
 
 {%- block pageTitle %}{% if section %}{{ section|capitalize }} | {% endif %}Design system | Digital Land{% endblock -%}
 
-{% block dlCss %}
+{%- block dlCss %}
 {{super()}}
-<link href="{{ staticPath|default('/static') }}/stylesheets/styleguide.css" rel="stylesheet" />
-{% endblock %}
+    <link href="{{ staticPath|default('/static') }}/stylesheets/styleguide.css" rel="stylesheet" />
+{% endblock -%}
 
 {% block main %}
 


### PR DESCRIPTION
Remove the link tag for the frontend css as it is already included in:
`/frontend/digital_land_frontend/templates/dlf-base.html`

Also updated the block to which this get's appended as there was a more specific block for CSS alone. Could prevent source order issues. 